### PR TITLE
OpenSSL build/doc fixes for heartbleed bug.

### DIFF
--- a/contrib/gitian-descriptors/deps-win32.yml
+++ b/contrib/gitian-descriptors/deps-win32.yml
@@ -14,7 +14,7 @@ packages:
 reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
-- "openssl-1.0.1c.tar.gz"
+- "openssl-1.0.1g.tar.gz"
 - "db-4.8.30.NC.tar.gz"
 - "miniupnpc-1.6.tar.gz"
 - "zlib-1.2.6.tar.gz"
@@ -30,8 +30,8 @@ script: |
   #
   mkdir -p $INSTALLPREFIX
 
-  tar xzf openssl-1.0.1c.tar.gz
-  cd openssl-1.0.1c
+  tar xzf openssl-1.0.1g.tar.gz
+  cd openssl-1.0.1g
   ./Configure --cross-compile-prefix=$HOST- mingw --openssldir=$INSTALLPREFIX
   make
   make install_sw
@@ -90,4 +90,4 @@ script: |
   cd ..
   #
   cd $INSTALLPREFIX
-  zip -r $OUTDIR/bitcoin-deps-win32-gitian-r9.zip include lib
+  zip -r $OUTDIR/bitcoin-deps-win32-gitian-r10.zip include lib

--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -16,9 +16,9 @@ remotes:
 - "url": "https://bitbucket.org/simondlr/the-cypherfunks.git"
   "dir": "Cypherfunk"
 files:
-- "qt-win32-4.8.5-gitian-r4.zip"
+- "qt-win32-4.8.5-gitian-r5.zip"
 - "boost-win32-1.55.0-gitian-r6.zip"
-- "bitcoin-deps-win32-gitian-r9.zip"
+- "bitcoin-deps-win32-gitian-r10.zip"
 script: |
   #
   STAGING=$HOME/staging
@@ -26,9 +26,9 @@ script: |
   #
   mkdir -p $STAGING
   cd $STAGING
-  unzip ../build/qt-win32-4.8.5-gitian-r4.zip
+  unzip ../build/qt-win32-4.8.5-gitian-r5.zip
   unzip ../build/boost-win32-1.55.0-gitian-r6.zip
-  unzip ../build/bitcoin-deps-win32-gitian-r9.zip
+  unzip ../build/bitcoin-deps-win32-gitian-r10.zip
   cd $HOME/build/
   #
   cd Cypherfunk

--- a/contrib/gitian-descriptors/qt-win32.yml
+++ b/contrib/gitian-descriptors/qt-win32.yml
@@ -15,7 +15,7 @@ reference_datetime: "2011-01-30 00:00:00"
 remotes: []
 files:
 - "qt-everywhere-opensource-src-4.8.5.tar.gz"
-- "bitcoin-deps-win32-gitian-r9.zip"
+- "bitcoin-deps-win32-gitian-r10.zip"
 script: |
   #
   HOST=i686-w64-mingw32
@@ -25,7 +25,7 @@ script: |
   mkdir -p $INSTDIR/host/bin
   #
   # Need mingw-compiled openssl from bitcoin-deps:
-  unzip bitcoin-deps-win32-gitian-r9.zip
+  unzip bitcoin-deps-win32-gitian-r10.zip
   DEPSDIR=`pwd`
   #
   tar xzf qt-everywhere-opensource-src-4.8.5.tar.gz
@@ -60,4 +60,4 @@ script: |
 
   # as zip stores file timestamps, use faketime to intercept stat calls to set dates for all files to reference date
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
-  zip -r $OUTDIR/qt-win32-4.8.5-gitian-r4.zip *
+  zip -r $OUTDIR/qt-win32-4.8.5-gitian-r5.zip *

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -99,7 +99,7 @@ Note: After you have installed the dependencies, you should check that the Brew 
 
         openssl version
 
-into Terminal. You should see OpenSSL 1.0.1e 11 Feb 2013.
+into Terminal. You should see OpenSSL 1.0.1g
 
 If not, you can ensure that the Brew OpenSSL is correctly linked by running
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -46,7 +46,7 @@ Licenses of statically linked libraries:
 
 - Versions used in this release:
 -  GCC           4.3.3
--  OpenSSL       1.0.1c
+-  OpenSSL       1.0.1g
 -  Berkeley DB   4.8.30.NC
 -  Boost         1.37
 -  miniupnpc     1.6


### PR DESCRIPTION
Fix so that build for windows wallet uses new openssl fix for Heartbleed. Docs also update to show that when building unix/mac wallets your local should be up to date.
